### PR TITLE
fix: vite build as `mjs`

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     build: {
       lib: {
         entry: "src/main/index.mts",
-        formats: ["cjs"],
+        formats: ["es"],
       },
     },
   },
@@ -17,7 +17,7 @@ export default defineConfig({
     build: {
       lib: {
         entry: "src/preload/index.mts",
-        formats: ["cjs"],
+        formats: ["es"],
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "GSCAP",
   "version": "1.0.0",
   "description": "An Electron application with React and TypeScript",
-  "main": "./out/main/index.js",
+  "main": "./out/main/index.mjs",
   "homepage": "https://electron-vite.org",
   "scripts": {
     "start": "electron-vite preview",


### PR DESCRIPTION
close #45 